### PR TITLE
Add .NET 5.0 support and update other .NET versions

### DIFF
--- a/dotnet/sdk/build-pipeline.groovy
+++ b/dotnet/sdk/build-pipeline.groovy
@@ -8,7 +8,7 @@ def PLATFORMS = [
 	"macos",
 	"ubuntu20"
 ]
-def DOTNET_SDK_VERSIONS = ["2.2.402", "3.1.404"]
+def DOTNET_SDK_VERSIONS = ["3.1.410", "5.0.301"]
 def DOTNET_SDK_VERSION = ""
 def CB_SERVER_VERSIONS = [
 	"7.0-stable",


### PR DESCRIPTION
- Add .NET 5.0 support
- Remove 2.2.402 as it has reached EOL (https://dotnet.microsoft.com/download/dotnet/2.2)
- Update 3.1.404  to latest security patch 3.1.410