### PR TITLE
NCBC-2947: ARM - Support for Apple Silicon (M1)

### DIFF
--- a/dotnet/sdk/build-pipeline.groovy
+++ b/dotnet/sdk/build-pipeline.groovy
@@ -134,11 +134,6 @@ pipeline {
         }
         stage("package") {
             agent { label "windows" }
-            when {
-                expression {
-                    return IS_GERRIT_TRIGGER.toBoolean() == false
-                }
-            }
             steps {
                 cleanWs(patterns: [[pattern: 'deps/**', type: 'EXCLUDE']])
                 unstash "couchbase-net-client-windows"


### PR DESCRIPTION
Motivation:
Support M1 with native .NET 6.0 binaries

Modifications:
* Skip .NET SDKs below 6.0 when on M1
* Pass explicit framework directive when using M1
* cbdep --info and --debug to verify correct architecture is being used