### PR TITLE
NCBC-3267: Update dotnet build scripts to better support versioning.

### DIFF
--- a/dotnet/sdk/apidoc-generation.groovy
+++ b/dotnet/sdk/apidoc-generation.groovy
@@ -1,0 +1,150 @@
+// Please do not Save the Jenkins pipeline with a modified script.
+// Instead, use the Replay function to test build script changes, then commit final changes
+// to the sdkbuilds-jenkinsfile repository.
+def DOTNET_SDK_VERSION = "6.0.101"
+
+// Windows has a 255 character path limit, still.
+// cbdep trying to unzip .NET SDK 5.0.x shows a FileNotFound error, which is really a PathTooLong error
+// using this path instead of WORKSPACE\deps gets around the issue.
+def CBDEP_WIN_PATH = "%TEMP%\\cbnc\\deps"
+
+pipeline {
+    agent none
+    stages {
+        stage("job valid?") {
+            when {
+                expression {
+                    return (API_REPO_NAME == "" || VERSION == "")
+                }
+            }
+            steps {
+                error("Exiting early as not valid run")
+            }
+        }
+        stage("prepare and validate") {
+            agent { label "centos6||centos7||ubuntu16||ubuntu14||ubuntu20" }
+            steps {
+                echo "API Repo Name: ${API_REPO_NAME}"
+				echo "SHA: ${SHA}"
+
+                cleanWs(patterns: [[pattern: 'deps/**', type: 'EXCLUDE']])
+                dir("${API_REPO_NAME}") {
+                    checkout([$class: "GitSCM", branches: [[name: "$SHA"]], userRemoteConfigs: [[url: "$REPO"]]])
+                }
+
+                dir("couchbase-apidocs-docfx") {
+                    checkout([$class: "GitSCM", userRemoteConfigs: [[url: "https://github.com/couchbaselabs/couchbase-apidocs-docfx.git"]]])
+                }
+
+                echo "Using dotnet core ${DOTNET_SDK_VERSION}"
+
+                stash includes: "${API_REPO_NAME}/", name: "${API_REPO_NAME}", useDefaultExcludes: false
+                stash includes: "couchbase-apidocs-docfx/", name: "couchbase-apidocs-docfx", useDefaultExcludes: false
+            }
+        }
+        stage("build") {
+            agent { label "windows" }
+            steps {
+                cleanWs(patterns: [[pattern: 'deps/**', type: 'EXCLUDE']])
+                unstash "${API_REPO_NAME}"
+                unstash "couchbase-apidocs-docfx"
+                installSDK("windows", DOTNET_SDK_VERSION)
+                script {
+                    env.PATH = "${PATH};${CBDEP_WIN_PATH}\\dotnet-core-sdk-${DOTNET_SDK_VERSION}"
+                    dir("couchbase-apidocs-docfx") {
+                        batWithEcho("powershell .\\Generate-ApiDocs.ps1 .\\${API_REPO_NAME}\\ -ApiVersion ${VERSION}") // -ZipOutput ${API_REPO_NAME}-${VERSION}.zip")
+                        dir("${API_REPO_NAME}") {
+                            zip dir: "_site", zipFile: "${API_REPO_NAME}-${VERSION}.zip", archive: true
+                            archiveArtifacts artifacts: "${API_REPO_NAME}-${VERSION}.zip", fingerprint: true
+                            stash includes: "${API_REPO_NAME}-${VERSION}.zip", name: "apidocs", useDefaultExcludes: false
+                            // // if (PUBLISH_TO_S3.toBoolean == true) {
+                            // //     dir("_site") {
+                            // //         withAWS(credentials: 'aws-sdk', region: 'us-west-1') {
+                            // //             s3Upload(
+                            // //                 bucket: 'docs.couchbase.com',
+                            // //                 path: "sdk-api/${API_REPO_NAME}-${VERSION}/",
+                            // //                 acl: 'PublicRead',
+                            // //                 file: 'docs/',
+                            // //             )
+                            // //         }       
+                            // //     }
+                            // // }
+                        }
+                    }
+                }
+            }
+        }
+        stage("approval") {
+            agent none
+            when {
+                expression {
+                    return PUBLISH_TO_S3.toBoolean() == true
+                }
+            }
+            steps {
+                input "Publish Generated API Docs to S3/sdk-api/${API_REPO_NAME}-${VERSION}/?"
+            }
+        }
+        stage("publish") {
+            agent { label "centos8" }
+            when {
+                expression {
+                    return PUBLISH_TO_S3.toBoolean() == true
+                }
+            }
+            steps {
+                cleanWs(patterns: [[pattern: 'deps/**', type: 'EXCLUDE']])
+
+                script {
+                    unstash "apidocs"
+                    unzip zipFile: "${API_REPO_NAME}-${VERSION}.zip", dir: "${API_REPO_NAME}-${VERSION}"
+                    withAWS(credentials: 'aws-sdk', region: 'us-west-1') {
+                        s3Upload(
+                            bucket: 'docs.couchbase.com',
+                            path: "sdk-api/${API_REPO_NAME}-${VERSION}/",
+                            acl: 'PublicRead',
+                            file: "${API_REPO_NAME}-${VERSION}/",
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+void shWithEcho(String command) {
+    echo "[$STAGE_NAME]"+ sh (script: command, returnStdout: true)
+}
+
+void batWithEcho(String command) {
+    echo "[$STAGE_NAME]"+ bat (script: command, returnStdout: true)
+}
+
+def installSDK(PLATFORM, DOTNET_SDK_VERSION) {
+    def install = false
+    def depsDir = "deps"
+    if (PLATFORM.contains("window")) {
+        depsDir = "%TEMP%\\cbnc\\deps"
+    }
+    dir(depsDir) {
+        dir("dotnet-core-sdk-${DOTNET_SDK_VERSION}") {
+            if (PLATFORM.contains("window")) {
+                install = !fileExists("dotnet.exe")
+            } else {
+                install = !fileExists("dotnet")
+            }
+        }
+    }
+
+    if (install) {
+        echo "Installing .NET SDK ${DOTNET_SDK_VERSION}"
+        if (PLATFORM.contains("window")) {
+            batWithEcho("cbdep install -d %TEMP%\\cbnc\\deps dotnet-core-sdk ${DOTNET_SDK_VERSION}")
+        } else {
+            shWithEcho("cbdep install -d deps dotnet-core-sdk ${DOTNET_SDK_VERSION}")
+        }
+    }
+    else {
+        echo ".NET SDK ${DOTNET_SDK_VERSION} for ${PLATFORM} is already installed."
+    }
+}

--- a/dotnet/sdk/publish-zipfile.groovy
+++ b/dotnet/sdk/publish-zipfile.groovy
@@ -1,0 +1,76 @@
+TO_PUBLISH = [ ]
+pipeline {
+    agent none
+    parameters {
+        string(name: 'BUILD_PIPELINE_NAME', defaultValue: 'couchbase-net-client-scripted-build-pipeline', description: 'Build pipeline to copy artifacts from.')
+    }
+    stages {
+        stage('Pick ZipFile') {
+            agent { label 'centos8||ubuntu16||ubuntu20' }
+            steps {
+                cleanWs()
+
+                // shWithEcho("cbdep install -d deps dotnet-core-sdk 6.0.101")
+                script {
+                    echo "SELECTED_BUILD = ${SELECTED_BUILD}"
+                    copyArtifacts(projectName: params.BUILD_PIPELINE_NAME, selector: buildParameter('SELECTED_BUILD'))
+                    zipFile = findFiles(glob: "**/Couchbase-Net-Client-*.zip")
+                    echo "zipFile = ${zipFile}"
+                    if (zipFile.length == 0) {
+                        error "No releease ZIPs found."
+                    }
+
+                    for (pkg in zipFile) {
+                        echo "pkg = ${pkg}"
+                        TO_PUBLISH.add(pkg.path)
+                    }
+
+                    def stashDir = "publish-zipfile-${BUILD_NUMBER}"
+                    dir (stashDir) {
+                        for (filePath in TO_PUBLISH) {
+                            shWithEcho("cp ../${filePath} .")
+                        }
+                    }
+
+                    stash name: stashDir, includes: "${stashDir}/*"
+                    dir(stashDir) {
+                        shWithEcho('ls -l')
+                    }
+                }
+            }
+        }
+        stage("approval") {
+            agent none
+            steps {
+                input "Continue with Publish to S3? (${TO_PUBLISH})"
+            }
+        }
+        stage('publish') {
+            agent { label 'centos8' }
+            steps {
+                cleanWs(patterns: [[pattern: 'deps/**', type: 'EXCLUDE']])
+                script {
+                    def stashDir = "publish-zipfile-${BUILD_NUMBER}"
+                    unstash stashDir
+                    dir(stashDir)
+                    {
+                        for (pkg in TO_PUBLISH) {
+                            withAWS(credentials: 'aws-sdk', region: 'us-east-1') {
+                                s3Upload(
+                                    bucket: 'packages.couchbase.com',
+                                    path: "clients/net/3.3/",
+                                    acl: 'PublicRead',
+                                    file: "${pkg}",
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+void shWithEcho(String command) {
+    echo sh (script: command, returnStdout: true)
+}


### PR DESCRIPTION
* Main script supports explicitly setting version string by VERSION jenkins configuration OR PACKAGE_VERSION=<whatever> in gerrit commit message.
* Updated ZIP file name to be properly capitalized as Couchbase-Net-Client-<version>.zip
* Added script for publish-zipfile job to automate uploading of binary distribution to S3
* Added script for apidoc-generation job (already being used, but previously only set direclty in the configuration section)