### PR TITLE
publish-nuget ignores *.symbols.nupkg files (use .snupkg instead)

### DIFF
--- a/dotnet/sdk/build-pipeline-encryption.groovy
+++ b/dotnet/sdk/build-pipeline-encryption.groovy
@@ -107,7 +107,7 @@ pipeline {
                                         }
                                     }
                                     // create zip file of release files and add it to archived artifacts
-                                    zip dir: "dotnet-couchbase-encryption/src/Couchbase.Encryption/bin/Release", zipFile: "Couchbase-Encryptio-${version}.zip", archive: true
+                                    zip dir: "dotnet-couchbase-encryption/src/Couchbase.Encryption/bin/Release", zipFile: "Couchbase-Encryption-${version}.zip", archive: true
 
                                     archiveArtifacts artifacts: "dotnet-couchbase-encryption/**/*.nupkg, dotnet-couchbase-encryption/**/*.snupkg", fingerprint: true
                                     stash includes: "dotnet-couchbase-encryption/**/Release/*.nupkg, dotnet-couchbase-encryption/**/Release/*.snupkg", name: "dotnet-couchbase-encryption-package", useDefaultExcludes: false

--- a/dotnet/sdk/publish-nuget.groovy
+++ b/dotnet/sdk/publish-nuget.groovy
@@ -28,7 +28,9 @@ pipeline {
                     def toPublish = [ ]
                     for (pkg in nugets) {
                         echo "pkg = ${pkg}"
-                        if (pkg =~ pattern) {
+                        if (pkg =~ ".*.symbols.nupkg") {
+                            echo "Skipping ${pkg} in favor of snupkg (build with /p:SymbolPackageFormat=snupkg or update your project files accordingly)"
+                        } else if (pkg =~ pattern) {
                             echo "${pkg} matches ${pattern}"
                             toPublish.add(pkg.path)
                         }


### PR DESCRIPTION
Fix typo in dotnet-couchbase-encryption script