### PR TITLE
[Ruby] Update platform/version matrix exclusions

### DIFF
--- a/ruby/ruby-build-pipeline.groovy
+++ b/ruby/ruby-build-pipeline.groovy
@@ -27,11 +27,21 @@ pipeline {
                     exclude {
                         axis {
                             name 'PLATFORM'
-                            notValues 'macos-11.0', 'macos-10.15', 'm1'
+                            notValues 'macos-11.0', 'm1'
                         }
                         axis {
                             name 'CB_RUBY_VERSION'
-                            values 'brew', '3.3'
+                            values 'brew'
+                        }
+                    }
+                    exclude {
+                        axis {
+                            name 'PLATFORM'
+                            values 'macos-11.0', 'macos-10.15', 'm1'
+                        }
+                        axis {
+                            name 'CB_RUBY_VERSION'
+                            values '3.3'
                         }
                     }
                     exclude {
@@ -130,11 +140,21 @@ pipeline {
                     exclude {
                         axis {
                             name 'PLATFORM'
-                            notValues 'macos-11.0', 'macos-10.15', 'm1'
+                            notValues 'macos-11.0', 'm1'
                         }
                         axis {
                             name 'CB_RUBY_VERSION'
-                            values 'brew', '3.3'
+                            values 'brew'
+                        }
+                    }
+                    exclude {
+                        axis {
+                            name 'PLATFORM'
+                            values 'macos-11.0', 'macos-10.15', 'm1'
+                        }
+                        axis {
+                            name 'CB_RUBY_VERSION'
+                            values '3.3'
                         }
                     }
                     exclude {


### PR DESCRIPTION
* Exclude Ruby 3.3 for the macOS platforms, previously it was excluded for the non-macOS platforms
* Exclude homebrew Ruby for macOS 10.15