### PR TITLE
[Ruby] Fix all runs having the '-notest' suffix

### DIFF
--- a/ruby/ruby-build-pipeline.groovy
+++ b/ruby/ruby-build-pipeline.groovy
@@ -8,7 +8,7 @@ pipeline {
             steps {
                 script {
                     def name = IS_PULL_REQUEST.toBoolean() ? "cv-${BUILD_NUMBER}" : "full-${BUILD_NUMBER}"
-                    if (SKIP_TESTS) {
+                    if (SKIP_TESTS.toBoolean()) {
                         name += "-notest"
                     }
                     buildName(name)


### PR DESCRIPTION
SKIP_TESTS needs `.toBoolean()` in the condition, otherwise it appears that it's always truthy